### PR TITLE
Added a line to the filter area adjusting the width, which fixed the

### DIFF
--- a/css/apolloui.css
+++ b/css/apolloui.css
@@ -2529,6 +2529,7 @@ border-radius: 100px;
 .home.catalog .catalog-search-bar .catalog-active-filters {
   display: flex;
   align-items: center;
+  width: 83%;
 }
 
 .home.catalog .widget--catalog .catalog-search-bar .catalog-display-type .btn--primary {


### PR DESCRIPTION
squashing effect when filters are applied.  Warrants further
investigation - it may have to do with the table display applied to one
of the parents, but I'm not 100% sure